### PR TITLE
chore(license): improve Apache 2.0 compliance with proper attribution to original author

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,21 @@
-Add github workflow actions
-Enable NFC permissions to write NFC tag data
-Security hardening
-UI updates
-Update package namespace
-Readme updates
+TapBlok
+
+Copyright 202x cajdata (original project)
+https://github.com/cajdata/TapBlok
+
+This project is a fork with substantial modifications, new features,
+UI updates, build improvements, and other changes.
+
+Modifications Copyright 2025-2026 Galynte
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 TapBlok — open‑source alternative to Brick and Bloom
 
+> **Attribution**: This project is a fork of the original [TapBlok by cajdata](https://github.com/cajdata/TapBlok), which was released under the Apache License 2.0. It includes substantial modifications, additional features (such as automatic session timeout, improved emergency override, QR code enhancements, modern Compose UI updates, CI improvements, and more), package namespace changes, and other enhancements by Galynte.
+
 TapBlok is a digital wellbeing and productivity tool for Android designed to help users regain control over their screen time. Our core philosophy is to create intentional friction. By requiring a physical action (scanning an NFC tag or QR code) to disable a focus session, we make it more difficult for users to impulsively bypass their own productivity goals.
 
 The app is built entirely in Kotlin and utilizes modern Android development practices, including Jetpack Compose for the UI, Room for local persistence, and Coroutines for asynchronous operations.
@@ -56,3 +58,11 @@ The application is composed of several key components that work together to prov
 ## Disclaimer
 
 All product names, trademarks, and registered trademarks are property of their respective owners.
+
+## License
+
+This project is licensed under the Apache License 2.0 — see the [LICENSE](LICENSE) file for details.
+
+The original TapBlok project by cajdata is also licensed under Apache 2.0.
+
+See the [NOTICE](NOTICE) file for attribution details regarding the original work and modifications.

--- a/app/src/main/java/com/galynte/tapblok/App.kt
+++ b/app/src/main/java/com/galynte/tapblok/App.kt
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2025-2026 Galynte
+ *
+ * This file is part of TapBlok, a fork of the original project by cajdata.
+ * Original: https://github.com/cajdata/TapBlok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.galynte.tapblok
 
 import android.app.Application

--- a/app/src/main/java/com/galynte/tapblok/AppMonitoringService.kt
+++ b/app/src/main/java/com/galynte/tapblok/AppMonitoringService.kt
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2025-2026 Galynte
+ *
+ * This file is part of TapBlok, a fork of the original project by cajdata.
+ * Original: https://github.com/cajdata/TapBlok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.galynte.tapblok
 
 import android.app.PendingIntent

--- a/app/src/main/java/com/galynte/tapblok/AppSelectionActivity.kt
+++ b/app/src/main/java/com/galynte/tapblok/AppSelectionActivity.kt
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2025-2026 Galynte
+ *
+ * This file is part of TapBlok, a fork of the original project by cajdata.
+ * Original: https://github.com/cajdata/TapBlok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.galynte.tapblok
 
 import android.app.Application

--- a/app/src/main/java/com/galynte/tapblok/BlockingActivity.kt
+++ b/app/src/main/java/com/galynte/tapblok/BlockingActivity.kt
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2025-2026 Galynte
+ *
+ * This file is part of TapBlok, a fork of the original project by cajdata.
+ * Original: https://github.com/cajdata/TapBlok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.galynte.tapblok
 
 import android.content.Context

--- a/app/src/main/java/com/galynte/tapblok/MainActivity.kt
+++ b/app/src/main/java/com/galynte/tapblok/MainActivity.kt
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2025-2026 Galynte
+ *
+ * This file is part of TapBlok, a fork of the original project by cajdata.
+ * Original: https://github.com/cajdata/TapBlok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.galynte.tapblok
 
 import android.Manifest

--- a/app/src/main/java/com/galynte/tapblok/NfcHandlerActivity.kt
+++ b/app/src/main/java/com/galynte/tapblok/NfcHandlerActivity.kt
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2025-2026 Galynte
+ *
+ * This file is part of TapBlok, a fork of the original project by cajdata.
+ * Original: https://github.com/cajdata/TapBlok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.galynte.tapblok
 
 import android.app.Activity

--- a/app/src/main/java/com/galynte/tapblok/NfcWriteActivity.kt
+++ b/app/src/main/java/com/galynte/tapblok/NfcWriteActivity.kt
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2025-2026 Galynte
+ *
+ * This file is part of TapBlok, a fork of the original project by cajdata.
+ * Original: https://github.com/cajdata/TapBlok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.galynte.tapblok
 
 import android.app.PendingIntent

--- a/app/src/main/java/com/galynte/tapblok/PrivacyExplanationActivity.kt
+++ b/app/src/main/java/com/galynte/tapblok/PrivacyExplanationActivity.kt
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2025-2026 Galynte
+ *
+ * This file is part of TapBlok, a fork of the original project by cajdata.
+ * Original: https://github.com/cajdata/TapBlok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.galynte.tapblok
 
 import android.content.Intent

--- a/app/src/main/java/com/galynte/tapblok/QrCodeActivity.kt
+++ b/app/src/main/java/com/galynte/tapblok/QrCodeActivity.kt
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2025-2026 Galynte
+ *
+ * This file is part of TapBlok, a fork of the original project by cajdata.
+ * Original: https://github.com/cajdata/TapBlok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.galynte.tapblok
 
 import android.graphics.Bitmap

--- a/app/src/main/java/com/galynte/tapblok/ServiceUtils.kt
+++ b/app/src/main/java/com/galynte/tapblok/ServiceUtils.kt
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2025-2026 Galynte
+ *
+ * This file is part of TapBlok, a fork of the original project by cajdata.
+ * Original: https://github.com/cajdata/TapBlok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.galynte.tapblok
 
 import android.app.AppOpsManager

--- a/app/src/main/java/com/galynte/tapblok/SettingsActivity.kt
+++ b/app/src/main/java/com/galynte/tapblok/SettingsActivity.kt
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2025-2026 Galynte
+ *
+ * This file is part of TapBlok, a fork of the original project by cajdata.
+ * Original: https://github.com/cajdata/TapBlok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.galynte.tapblok
 
 import android.content.Intent
@@ -275,6 +294,9 @@ fun SettingsScreen(
                         ) {
                             Text(
                                 text = """
+                                This app is a modified version of the original TapBlok project
+                                created by cajdata (https://github.com/cajdata/TapBlok).
+
                                 Apache License
                                 Version 2.0, January 2004
                                 http://www.apache.org/licenses/

--- a/app/src/main/java/com/galynte/tapblok/ui/components/TapBlokScaffold.kt
+++ b/app/src/main/java/com/galynte/tapblok/ui/components/TapBlokScaffold.kt
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2025-2026 Galynte
+ *
+ * This file is part of TapBlok, a fork of the original project by cajdata.
+ * Original: https://github.com/cajdata/TapBlok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.galynte.tapblok.ui.components
 
 import androidx.compose.foundation.layout.PaddingValues


### PR DESCRIPTION
### Summary
This PR improves Apache 2.0 license compliance for the fork of the original [TapBlok by cajdata](https://github.com/cajdata/TapBlok).

The project had the `LICENSE` file but was missing proper attribution, notices in modified files, and clear fork provenance in documentation. These changes bring the repo in line with Apache 2.0 requirements for derivative works (particularly sections 4(b) and 4(c) around prominent notices and retained attribution).

### Changes
- **README.md**: Added prominent fork/attribution notice near the top and a dedicated `## License` section that references both the original project and the `NOTICE` file.
- **NOTICE**: Replaced the previous personal changelog content with a proper Apache-style attribution file that credits the original work by cajdata and documents the modifications.
- **In-app license dialog** (`SettingsActivity.kt`): Updated the "Open Source Licenses" dialog to explicitly state that this is a modified version of the original TapBlok project by cajdata.
- **Source files**: Added consistent copyright headers (with Apache 2.0 boilerplate + fork attribution) to all core Kotlin source files. This provides the required "prominent notices stating that You changed the files."

The original upstream project did not ship a `NOTICE` file with specific attributions, so we created one that is additive and clearly distinguishes the original work from the modifications.

### Why
Apache 2.0 requires that when redistributing derivative works (especially when rebranding, changing package names, and publishing binaries), you:
- Retain original attribution notices
- Add notices for your modifications
- Provide clear provenance for downstream users and distributors

These updates make the fork's relationship to the original project transparent while still allowing the current branding and modifications.

### Testing / Verification
- `LICENSE` file remains untouched and correct.
- In-app license viewer now includes proper upstream credit.
- Source headers are present on all primary modified files.
- README and NOTICE are now accurate.